### PR TITLE
Only render layout on first call

### DIFF
--- a/lib/scorched/controller.rb
+++ b/lib/scorched/controller.rb
@@ -409,13 +409,9 @@ module Scorched
       end
     
       # The following chunk of code is responsible for preventing the rendering of layouts within views.
-      begin
-        @_no_default_layout = true
-        output = template.render(self, locals, &block)
-      ensure
-        @_no_default_layout = false
-      end
-      
+      @_no_default_layout = true
+      output = template.render(self, locals, &block)
+
       if layout
         render(layout, dir: dir, layout: false, engine: engine, locals: locals, tilt: tilt, **options) { output }
       else


### PR DESCRIPTION
This updates the logic around rendering a layout when `render` is called and a default layout is set.

Since multiple calls to render from a Controller are unnecessary, there should be no need to return `@_no_default_layout` to false again, and currently returning the value to `true` means that additional calls to `render` inside a view will start rendering the default layout again.

Although I locally updated the specs and tested it, I didn't include that since there is already a test about rendering inside a view. It was just a matter of updating `composer.erb` and rendering the partial twice to test.
