### PR TITLE
Fix URL generation in subcontrollers

### DIFF
--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -1003,15 +1003,9 @@ module Scorched
       end
       
       let(:root_app) do
-        app = Class.new(Scorched::Controller)
+        Class.new(Scorched::Controller)
       end
 
-      let(:sub_root_app) do
-        app = Class.new(Scorched::Controller)
-        root_app.map pattern: '/sub', target: app
-        app
-      end
-      
       let(:app) do
         this = self
         builder = Rack::Builder.new
@@ -1039,11 +1033,6 @@ module Scorched
           rt.get('/myapp').body.should == test_url
         end
         
-        it "generates URL from inside subcontroller" do
-          sub_root_app.get('/') { url('hi') }
-          rt.get('https://scorchedrb.com:73/sub').body.should == 'https://scorchedrb.com:73/sub/hi'
-        end
-
         it "generates URL from inside subcontroller defined with controller helper" do
           root_app.controller '/sub2' do
             get('/') { url('hi') }
@@ -1074,11 +1063,6 @@ module Scorched
           rt.get('/myapp').body.should == test_url
         end
         
-        it "returns an absolute URL path for subcontroller" do
-          sub_root_app.get('/') { absolute }
-          rt.get('http://scorchedrb.com/sub').body.should == '/sub'
-        end
-
         it "returns an absolute URL path for subcontroller defined with controller helper" do
           root_app.controller '/sub2' do
             get('/') { absolute }


### PR DESCRIPTION
Currently when calling subcontrollers Scorched mangles `PATH_INFO` but doesn't do anything with `SCRIPT_NAME` which violates `SCRIPT_NAME + PATH_INFO = url path` invariant. This also makes URL generation non-intuitive cause it always generate URL as they are relative to root controller.

I added specs (which currently fail) which define that subcontrollers should operate as independent Rack apps and generate URL relative to themselves.

I think this is the sane default behaviour because it enables `Scorched::Controller` to be "relocatable" — to be independent of the URL it is mapped to. I think one can also override this behaviour by choosing to use `scorched.script_name` (to be introduced) instead of mangled `SCRIPT_NAME`.

The only place I would like to keep the current behaviour is controllers defined with `controller` helper. Because they are not "relocatable" and don't need to be such they are expected to produce URLs relative to their parent. I think we can introduce optional argument to `map` which would define if Scorched should treat subcontroller as a separate Rack app or just as a namespace.
- [x] mangle `SCRIPT_NAME` along with `PATH_INFO` when calling subcontrollers
- [x] introduce `scorched.script_name` which stores original `SCRIPT_NAME` value
- [x] decide and implement if need special behaviour for controllers mounted with `controller` helpers

This pull request builds up on #16
