### PR TITLE
helpers for LINK, UNLINK HTTP methods

### DIFF
--- a/lib/scorched/controller.rb
+++ b/lib/scorched/controller.rb
@@ -178,7 +178,7 @@ module Scorched
         target
       end
       
-      ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'].each do |method|
+      ['get', 'post', 'put', 'delete', 'head', 'options', 'patch', 'link', 'unlink'].each do |method|
         methods = (method == 'get') ? ['GET', 'HEAD'] : [method.upcase]
         define_method(method) do |*args, **conds, &block|
           conds.merge!(method: methods)


### PR DESCRIPTION
as per RFC 2068, sections 19.6.1.2 and 19.6.1.3, see
http://tools.ietf.org/html/rfc2068

this related to #18
