### PR TITLE
change action name

### DIFF
--- a/examples/restful_controller.ru
+++ b/examples/restful_controller.ru
@@ -13,7 +13,7 @@ module Scorched
       klass.get('/:id') { |id| invoke_action :show, id }
       klass.get('/:id/edit') { |id| invoke_action :edit, id }
       klass.route('/:id', method: ['PATCH', 'PUT']) { |id| invoke_action :update, id }
-      klass.delete('/:id') { |id| invoke_action :delete, id }
+      klass.delete('/:id') { |id| invoke_action :destroy, id }
     end
 
     def invoke_action(action, *captures)


### PR DESCRIPTION
Just noticed this discrepancy. Have differentiated verb name from action name

As an aside I have made a local gem which implements this as well as an abstract interface with informative errors for missing actions. Do you have any grand plans to include plugins withing the main scorched repository or would it be best a separate gem perhaps referenced somewhere?